### PR TITLE
Add support for dynamic property naming

### DIFF
--- a/prop.rkt
+++ b/prop.rkt
@@ -22,10 +22,10 @@
 
 (define-syntax (property stx)
   (syntax-parse stx
-    [(_ (~optional name:id)
+    [(_ (~optional (~seq #:name name:expr))
         ([id:id g:expr] ...)
         body ...+)
-     #'(prop (~? 'name 'unnamed)
+     #'(prop (~? name 'unnamed)
              (list 'id ...)
              (gen:let ([id g] ...)
                (list id ...))
@@ -36,7 +36,7 @@
   (syntax-parse stx
     [(_ name:id binds body ...+)
      #'(define name
-         (property name binds body ...))]))
+         (property #:name 'name binds body ...))]))
 
 (module+ test
   (require "gen/base.rkt")

--- a/rackcheck.scrbl
+++ b/rackcheck.scrbl
@@ -389,7 +389,7 @@ Don't use them to produce values for your tests.
   Returns @racket[#t] when @racket[v] is a property.
 }
 
-@defform[(property ([id gen-expr] ...) body ...+)]{
+@defform[(property [#:name name symbol? 'unnamed] ([id gen-expr] ...) body ...+)]{
   Declares a property where the inputs are one or more generators.
 
   @ex[


### PR DESCRIPTION
This changes the property macro from accepting an optional identifier in the first position to an optional named argument `#:name`, this makes it possible to specify property names dynamically in things like property generating functions. The name had to be made a named argument otherwise there would be ambiguity in the macro syntax.