### PR TITLE
Expose prop-name as property-name

### DIFF
--- a/examples/list.rkt
+++ b/examples/list.rkt
@@ -18,7 +18,7 @@
      ([xs (gen:list gen:natural)])
      (let ([f (lambda (n) (* 3 (add1 n)))]
            [g (lambda (n) (/ n 2))])
-      (check-equal? (map f (map g xs)) (map (compose f g) xs))))
+      (check-equal? (map f (map g xs)) (map (compose1 f g) xs))))
 
    (define (test-property prop)
      (test-case (symbol->string (property-name prop))

--- a/examples/list.rkt
+++ b/examples/list.rkt
@@ -1,8 +1,7 @@
 #lang racket/base
 
 (module+ test
-  (require racket/function
-           rackcheck
+  (require rackcheck
            rackunit)
 
   (define-property prop-list-reverse
@@ -11,7 +10,7 @@
 
   (define-property prop-list-map-identity
     ([xs (gen:list gen:natural)])
-    (check-equal? (map identity xs) xs))
+    (check-equal? (map values xs) xs))
 
   (property-name prop-list-map-identity)
 

--- a/examples/list.rkt
+++ b/examples/list.rkt
@@ -1,11 +1,32 @@
 #lang racket/base
 
 (module+ test
-  (require rackcheck
+  (require racket/function
+           rackcheck
            rackunit)
 
   (define-property prop-list-reverse
     ([xs (gen:list gen:natural)])
     (check-equal? (reverse (reverse xs)) xs))
 
-  (check-property prop-list-reverse))
+  (define-property prop-list-map-identity
+    ([xs (gen:list gen:natural)])
+    (check-equal? (map identity xs) xs))
+
+  (property-name prop-list-map-identity)
+
+  (define-property prop-list-map-composition
+     ([xs (gen:list gen:natural)])
+     (let ([f (lambda (n) (* 3 (add1 n)))]
+           [g (lambda (n) (/ n 2))])
+      (check-equal? (map f (map g xs)) (map (compose f g) xs))))
+
+   (define (test-property prop)
+     (test-case (symbol->string (property-name prop))
+         (check-property prop)))
+
+  (test-property prop-list-reverse)
+
+  (test-property prop-list-map-identity)
+
+  (test-property prop-list-map-composition))

--- a/prop.rkt
+++ b/prop.rkt
@@ -12,7 +12,8 @@
 ;; property ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (provide
- (rename-out [prop? property?])
+ (rename-out [prop? property?]
+             [prop-name property-name])
  property
  define-property)
 

--- a/rackcheck.scrbl
+++ b/rackcheck.scrbl
@@ -3,7 +3,6 @@
 @(require scribble/example
           (for-label racket/base
                      racket/contract
-                     racket/function
                      racket/stream
                      racket/string
                      rackcheck
@@ -493,7 +492,7 @@ Don't use them to produce values for your tests.
   @ex[
     (define-property prop-list-map-identity
      ([xs (gen:list gen:natural)])
-     (check-equal? (map identity xs) xs))
+     (check-equal? (map values xs) xs))
 
     (property-name prop-list-map-identity)
   ]

--- a/rackcheck.scrbl
+++ b/rackcheck.scrbl
@@ -3,6 +3,7 @@
 @(require scribble/example
           (for-label racket/base
                      racket/contract
+                     racket/function
                      racket/stream
                      racket/string
                      rackcheck
@@ -483,6 +484,18 @@ Don't use them to produce values for your tests.
     (check-property
      (property ([xs (gen:list gen:natural)])
        (check-equal? (reverse xs) xs)))
+  ]
+}
+
+@defproc[(property-name [property any/c]) any/c?]{
+  Returns name of the @racket[property].
+
+  @ex[
+    (define-property prop-list-map-identity
+     ([xs (gen:list gen:natural)])
+     (check-equal? (map identity xs) xs))
+
+    (property-name prop-list-map-identity)
   ]
 }
 


### PR DESCRIPTION
In some cases it is useful to use prop-name, for example if we have property:

```racket
(define-property prop-list-map-composition
  ([xs (gen:list gen:natural)])
  (let ([f (lambda (n) (* 3 (add1 n)))]
          [g (lambda (n) (/ n 2))])
      (check-equal? (map f (map g xs)) (map (compose f g) xs))))
```

and we want to run it as racketunit test-case providing the same name. Currently prop struct is not exposed. If we have `prop-name` lets say as `property-name`, we could define helper:

```racket
(define (test-property prop)
  (test-case (symbol->string (property-name prop))
  (check-property prop)))
```

and now: 
```racket
(test-property prop-list-map-composition))
```

This PR attempt to achieve this. WDYT @Bogdanp